### PR TITLE
Handle the case when observed node placed inside of detached iframe in ie11

### DIFF
--- a/src/utils/getWindowOf.js
+++ b/src/utils/getWindowOf.js
@@ -1,6 +1,27 @@
 import global from '../shims/global.js';
 
 /**
+ * Checks that target has a defaultView
+ * @param  {Object} target
+ * @return {Boolean}
+ */
+function checkDefaultViewExisting(target) {
+  const simplyExists = target
+    && target.ownerDocument
+    && target.ownerDocument.defaultView;
+
+  /**
+   * That case will work when target is an element inside of detached iframe.
+   * In Chrome it will end up with null by "target.ownerDocument.defaultView" path
+   * but in IE11 it will become a window with bunch of undefined properties so
+   * we should follow the duck typing way.
+   */
+  const nonEmptyWindow = !!(simplyExists && target.ownerDocument.defaultView.Object);
+
+  return nonEmptyWindow;
+}
+
+/**
  * Returns the global object associated with provided element.
  *
  * @param {Object} target
@@ -10,7 +31,9 @@ export default target => {
     // Assume that the element is an instance of Node, which means that it
     // has the "ownerDocument" property from which we can retrieve a
     // corresponding global object.
-    const ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView;
+    var ownerGlobal = checkDefaultViewExisting(target)
+      ? target.ownerDocument.defaultView
+      : null;
 
     // Return the local global object if it's not possible extract one from
     // provided element.


### PR DESCRIPTION
There is the case when node that should be observed placed inside of iframe that will be detached in some cases. In Chrome it will work just fine because defaultView there becomes null, but in ie it gets the following structure 
![image](https://user-images.githubusercontent.com/23152279/43838202-60142040-9b23-11e8-98ce-2ab9f5c5a32a.png)
That case leads to the error in the **isSVGGraphicsElement** function due to the lack of SVGElement(as well as other properties)
![image](https://user-images.githubusercontent.com/23152279/43838408-f16f7030-9b23-11e8-9fe2-56a9b92b02f4.png)
When getWindowOf returns the window with undefined properties the next step "**target instanceof getWindowOf(target).SVGElement**" raise an error
