### PR TITLE
Fix the typescript type declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,4 +37,4 @@ interface ResizeObserver {
     disconnect(): void;
 }
 
-export default ResizeObserver;
+export = ResizeObserver;


### PR DESCRIPTION
In typescript (with webpack), a default import doesn't work:

```typescript
import ResizeObserver from 'resize-observer-polyfill';
```

but a star import or an `import = require` import do work:
```typescript
import * as ResizeObserver from 'resize-observer-polyfill';
```
or:
```typescript
import ResizeObserver = require('resize-observer-polyfill');
```

Apparently there is a closed issue about this. This fixes #24.