### PR TITLE
Trigger refresh on font load event

### DIFF
--- a/dist/ResizeObserver.js
+++ b/dist/ResizeObserver.js
@@ -218,6 +218,8 @@
     var transitionKeys = ['top', 'right', 'bottom', 'left', 'width', 'height', 'size', 'weight'];
     // Check if MutationObserver is available.
     var mutationObserverSupported = typeof MutationObserver !== 'undefined';
+    //Check if FontFaceSet is available
+    var fontFaceSetIsSupported = isBrowser && typeof document.fonts !== 'undefined';
     /**
      * Singleton controller class which handles updates of ResizeObserver instances.
      */
@@ -353,6 +355,10 @@
                 document.addEventListener('DOMSubtreeModified', this.refresh);
                 this.mutationEventsAdded_ = true;
             }
+            if (fontFaceSetIsSupported) {
+                this.fontFaceSet_ = document.fonts;
+                this.fontFaceSet_.addEventListener('loadingdone', this.refresh);
+            }
             this.connected_ = true;
         };
         /**
@@ -375,7 +381,11 @@
             if (this.mutationEventsAdded_) {
                 document.removeEventListener('DOMSubtreeModified', this.refresh);
             }
+            if (this.fontFaceSet_) {
+                this.fontFaceSet_.removeEventListener('loadingdone', this.refresh);
+            }
             this.mutationsObserver_ = null;
+            this.fontFaceSet_ = null;
             this.mutationEventsAdded_ = false;
             this.connected_ = false;
         };

--- a/src/ResizeObserverController.js
+++ b/src/ResizeObserverController.js
@@ -11,6 +11,9 @@ const transitionKeys = ['top', 'right', 'bottom', 'left', 'width', 'height', 'si
 // Check if MutationObserver is available.
 const mutationObserverSupported = typeof MutationObserver !== 'undefined';
 
+//Check if FontFaceSet is available
+const fontFaceSetIsSupported = isBrowser && typeof document.fonts !== 'undefined';
+
 /**
  * Singleton controller class which handles updates of ResizeObserver instances.
  */
@@ -173,6 +176,11 @@ export default class ResizeObserverController {
             this.mutationEventsAdded_ = true;
         }
 
+        if (fontFaceSetIsSupported) {
+            this.fontFaceSet_ = document.fonts;
+            this.fontFaceSet_.addEventListener('loadingdone', this.refresh);
+        }
+
         this.connected_ = true;
     }
 
@@ -200,7 +208,12 @@ export default class ResizeObserverController {
             document.removeEventListener('DOMSubtreeModified', this.refresh);
         }
 
+        if (this.fontFaceSet_) {
+            this.fontFaceSet_.removeEventListener('loadingdone', this.refresh);
+        }
+
         this.mutationsObserver_ = null;
+        this.fontFaceSet_ = null;
         this.mutationEventsAdded_ = false;
         this.connected_ = false;
     }

--- a/tests/ResizeObserver.spec.js
+++ b/tests/ResizeObserver.spec.js
@@ -31,12 +31,23 @@ const css = `
     #target2 {
         background: #fbbc05;
     }
+    
+    #target3 {
+        font-family: 'BioRhyme Expanded', serif;
+        width: 100%;
+        height: 100%;
+        position: relative;
+        background: #cbbcf7;
+    }
 `;
 const template = `
     <div id="root">
         <div id="container">
             <div id="target1"></div>
             <div id="target2"></div>
+            <div id="target3">
+              <span>Text</span>
+            </div>
         </div>
     </div>
 `;
@@ -1154,6 +1165,47 @@ describe('ResizeObserver', () => {
                 }).then(done).catch(done.fail);
             });
         }
+
+        describe('handles font load', () => {
+            if (typeof document.fonts !== 'undefined') {
+                it('triggers when FontFaceSet is supported and font is loaded', done => {
+                    const bioRhymeFontFace = new FontFace('BioRhyme Expanded', 'url(https://fonts.gstatic.com/s/' +
+                        'biorhymeexpanded/v4/i7dQIE1zZzytGswgU577CDY9LjbffxSdT3GtYdjflKY.woff2)');
+
+                    document.fonts.add(bioRhymeFontFace);
+
+                    const spy = createAsyncSpy();
+
+                    observer = new ResizeObserver(spy);
+                    observer.observe(elements.target3);
+
+                    spy.nextCall().then(entries => {
+                        expect(entries.length).toBe(1);
+                        expect(entries[0].target).toBe(elements.target3);
+                    }).then(async () => {
+                        bioRhymeFontFace.load();
+                        const entries = await spy.nextCall();
+
+                        expect(entries.length).toBe(1);
+                        expect(entries[0].target).toBe(elements.target3);
+                    }).then(done).catch(done.fail);
+                });
+            }
+
+            if (typeof document.fonts === 'undefined') {
+                it('does not throw when FontFaceSet is not supported', done => {
+                    const spy = createAsyncSpy();
+
+                    observer = new ResizeObserver(spy);
+                    observer.observe(elements.target3);
+
+                    spy.nextCall().then(entries => {
+                        expect(entries.length).toBe(1);
+                        expect(entries[0].target).toBe(elements.target3);
+                    }).then(done).catch(done.fail);
+                });
+            }
+        });
     });
 
     describe('unobserve', () => {


### PR DESCRIPTION
In case FontFaceSet is supported by the browser:
- Listen to font load event
- Trigger refresh when font is loaded to detect possible changes in elements' size