### PR TITLE
Remove save-dev from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Follows the [spec](http://rawgit.com/WICG/ResizeObserver/master/index.html) and 
 From NPM:
 
 ```sh
-npm install resize-observer-polyfill --save-dev
+npm install resize-observer-polyfill
 ```
 
 ~~From Bower:~~ (will be removed with the next major release)
 
 ```sh
-bower install resize-observer-polyfill --save-dev
+bower install resize-observer-polyfill
 ```
 
 


### PR DESCRIPTION
If this is intended to be used as a [ponyfill](https://github.com/sindresorhus/ponyfill) (global object not overwritten), then this will be shipped to the browser in some shape or form, alongside the native API.

Therefore it would be would be wrong to assume this is a dev-dependency.