### PR TITLE
Update index.d.ts to avoid erros with new TS

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ interface DOMRectReadOnly {
     readonly right: number;
     readonly bottom: number;
     readonly left: number;
+    toJSON(): any;
 }
 
 declare global {


### PR DESCRIPTION
This unique line solves the following error when updating for newer TS versions:

Error: node_modules/resize-observer-polyfill/src/index.d.ts:19:18 - error TS2717: Subsequent property declarations must have the same type.  Property 'contentRect' must be of type 'DOMRectReadOnly', but here has type 'DOMRectReadOnly'.

It is related with issues #80, #53 and #73.