### PR TITLE
Add "sideEffects: false" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "description": "A polyfill for the Resize Observer API",
     "main": "dist/ResizeObserver.js",
     "module": "dist/ResizeObserver.es.js",
+    "sideEffects": false,
     "scripts": {
         "build": "rollup -c && cpy src/index.js.flow dist --rename=ResizeObserver.js.flow",
         "test": "npm run test:lint && npm run test:spec",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good for esm, modules, named imports.

rollup https://rollupjs.org/configuration-options/#treeshake-modulesideeffects webpack https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free